### PR TITLE
Fixes errors compiling t130_leaf_flutter

### DIFF
--- a/t130_leaf_flutter/pubspec.yaml
+++ b/t130_leaf_flutter/pubspec.yaml
@@ -23,5 +23,6 @@ flutter:
   uses-material-design: true
 
   module:
+    androidX: true
     androidPackage: com.example.t130_leaf_flutter
     iosBundleIdentifier: com.example.t130LeafFlutter


### PR DESCRIPTION
The compilation error was due to the generated Android module (.android) not using AndroidX. Support for generating this module with AndroidX support was recently merged so just needed to be enabled.